### PR TITLE
-cオプションを追加

### DIFF
--- a/Graph/src/graph.cpp
+++ b/Graph/src/graph.cpp
@@ -22,7 +22,7 @@ namespace POLDAM
         }
         PoldamGraph::pushStackVertex(v, threadId);
         // Thread IDのことは考えないことにする。
-        if (this->g[v].methodStr == config.entryMethodName && this->root.find(threadId) == this->root.end())
+        if (this->g[v].classStr == config.entryClassName && this->g[v].methodStr == config.entryMethodName && this->root.find(threadId) == this->root.end())
         {
             this->Root = v;
             this->g[v].isTargetVertex = true;

--- a/Graph/src/graph.h
+++ b/Graph/src/graph.h
@@ -26,6 +26,7 @@ namespace POLDAM
     struct GraphVertex
     {
     public:
+        std::string classStr{};
         // method hash is the hash of method
         std::string methodStr{};
         std::string methodHash{};

--- a/Util/include/src/cmd.cpp
+++ b/Util/include/src/cmd.cpp
@@ -10,6 +10,7 @@ namespace POLDAM
                   << "-o [original_selogger_directory] -t [target_selogger_directory] -m [target_method] -d [diff_file_name] \n";
         std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "-o, The path to the original directory. This parameter is mandatory and must point to a valid selogger output directory.\n";
         std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "-t, The path to the target directory. This directory data  This parameter is mandatory and must point to a valid selogger output directory.\n";
+        std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "-c, The Merkle tree will be constructed using the class specified by the -c option and -m option as the entry point.\n";
         std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "-m, The Merkle tree will be constructed using the method specified by the -m option as the entry point.\n";
         std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "-d, The file name of the diff file\n";
         std::cout << POLDAM_UTIL::POLDAM_PRINT_SUFFIX << "--debug, enalbe debug mode.\n";
@@ -51,6 +52,18 @@ namespace POLDAM
                 config.targetDir = argv[i + 1];
                 ++i;
             }
+            else if (arg == "-c")
+            {
+                if (i + 1 >= argc)
+                {
+                    std::cout << POLDAM_UTIL::POLDAM_ERROR_PRINT_SUFFIX << "No targetMethod is Given\n";
+                    printHelp();
+                    return poldamConfig{};
+                }
+                config.entryClassName = argv[i + 1];
+                config.hasEntryClassName = true;
+                ++i;
+            }
             else if (arg == "-m" or arg == "--targetMethod")
             {
                 if (i + 1 >= argc)
@@ -63,6 +76,7 @@ namespace POLDAM
                 config.hasEntryMethodName = true;
                 ++i;
             }
+
             else if (arg == "-d" or arg == "--difffilename")
             {
                 if (i + 1 > argc)

--- a/Util/include/src/poldam_config.hpp
+++ b/Util/include/src/poldam_config.hpp
@@ -1,3 +1,5 @@
+
+
 #pragma once
 #include <iostream>
 #include <string>
@@ -11,12 +13,14 @@ namespace POLDAM
         std::string originDir{};
         std::string targetDir{};
         std::string outputFileName{};
+        std::string entryClassName{};
         std::string entryMethodName{};
 
         bool useFastIO = false;
         bool isDebugMode = false;
         bool useFlowHash = false;
         bool useParamHash = false;
+        bool hasEntryClassName = false;
         bool hasEntryMethodName = false;
 
         bool operator==(const poldamConfig &c)
@@ -30,6 +34,7 @@ namespace POLDAM
                 c.isDebugMode == isDebugMode &&
                 c.useFlowHash == useFlowHash &&
                 c.useParamHash == useParamHash &&
+                c.hasEntryClassName == hasEntryClassName &&
                 c.hasEntryMethodName == hasEntryMethodName);
         }
     };

--- a/main.cpp
+++ b/main.cpp
@@ -112,7 +112,7 @@ POLDAM::PoldamGraph buildGraph(POLDAM::poldamConfig config, const std::string in
         {
             POLDAM::GraphVertex v;
             const unsigned int classId = dataId.classId;
-
+            v.classStr = m.className;
             v.methodStr = m.methodName;
             v.methodHash = std::to_string(std::hash<std::string>()(m.className + m.methodName));
             v.outputFormat = m.className + ":" + m.methodName;


### PR DESCRIPTION
-c optionでpackage名+クラス名で指定できるようにしました

懸念点は以下の通りです
- printhelpでオプションの表示の際の説明
- cオプションを使ったら-mを使うように制約を課すようにできていない
- Graph/src/graph.cpp#16行目でentryMethodNameが明示的に与えられなかった場合は、-cでクラスを指定しても最初の頂点をthis->Rootに設定していること